### PR TITLE
fixed two bugs in map.ex that did not correctly deal with nil or falsy values

### DIFF
--- a/lib/outstanding/map.ex
+++ b/lib/outstanding/map.ex
@@ -4,10 +4,14 @@ defoutstanding expected :: Map, actual :: Any do
   case Outstand.type_of(actual) do
     Map ->
       Map.keys(expected)
-      |> Enum.filter(&(Outstanding.outstanding(expected[&1], actual[&1])))
+      |> Enum.filter(fn key ->
+        not Map.has_key?(actual, key) or
+          Outstanding.outstanding(expected[key], actual[key]) != nil
+      end)
       |> Enum.into(%{}, &{&1, Outstanding.outstanding(expected[&1], actual[&1])})
       |> Outstand.suppress()
+
     _ ->
       expected
-    end
+  end
 end

--- a/test/map_test.exs
+++ b/test/map_test.exs
@@ -4,8 +4,12 @@ defmodule Outstanding.MapTest do
 
   gen_something_outstanding_test("key outstanding", %{x: :a, y: :b}, %{x: :a, z: :b})
   gen_something_outstanding_test("value outstanding", %{x: :a, y: :b}, %{x: :b, y: :b})
+  gen_something_outstanding_test("key nil value outstanding", %{x: :a, y: nil}, %{x: :a, z: :b})
+  gen_something_outstanding_test("value falsy outstanding",  %{x: false, y: :b}, %{x: :b, y: :b})
   gen_nothing_outstanding_test("realized", %{x: :a, y: :b}, %{x: :a, y: :b})
   gen_nothing_outstanding_test("realized with extra item", %{x: :a, y: :b}, %{x: :a, y: :b, z: :b})
   gen_result_outstanding_test("key result", %{x: :a, y: :b}, %{x: :a, z: :b}, %{y: :b})
-  gen_result_outstanding_test("value result", %{x: :a, y: :b}, %{x: :b, y: :b},  %{x: :a})
+  gen_result_outstanding_test("value result", %{x: :a, y: :b}, %{x: :b, y: :b}, %{x: :a})
+  gen_result_outstanding_test("key nil result", %{x: :a, y: nil}, %{x: :a, z: :b}, %{y: nil})
+  gen_result_outstanding_test("value falsy result", %{x: false, y: :b}, %{x: :b, y: :b}, %{x: false})
 end


### PR DESCRIPTION
Found and resolved two suspected bugs in map.ex calculation of outstanding

1. Where actual has a missing key but the value is nil 

```
iex(2)> outstanding(%{x: :a, y: nil}, %{x: :a, z: :b})
nil
```

2. Where actual has the key but wrong value and the expected value is falsy 
```
iex(3)> outstanding(%{x: false}, %{x: 10})
nil
```

To me (2) definitively seems like a bug, but I could see (1) may not be depending on your expected semantics. 